### PR TITLE
Author name use git config

### DIFF
--- a/pip_init/__init__.py
+++ b/pip_init/__init__.py
@@ -1,6 +1,20 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from pip_init.templates import setup_base_template, setup_line
+from subprocess import Popen, PIPE
+
+
+def git_config(key):
+    '''Get git config values.'''
+
+    # run git config --global <key> to get global git config value
+    p = Popen(['git', 'config', '--global', key], stdout=PIPE, stderr=PIPE)
+    output, err = p.communicate()
+
+    # turn stdout into unicode and strip it
+    output = output.decode('utf-8').strip()
+
+    return output
 
 
 def default_values(field_name):
@@ -13,7 +27,7 @@ def default_values(field_name):
     elif field_name == 'license':
         return 'MIT'
     elif field_name == 'author':
-        return 'Author name'
+        return git_config('user.name')
 
 
 def main():


### PR DESCRIPTION
Run `git config --global user.name` to retrieve author name, so we don't need to enter it every time.
