### PR TITLE
Use textwrap.dedent instead of multi string series

### DIFF
--- a/pip_init/templates.py
+++ b/pip_init/templates.py
@@ -1,22 +1,23 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from string import Template
+from textwrap import dedent
 
-setup_base_template = Template(
-    'from setuptools import setup, find_packages\n'
-    '\n'
-    'try:\n'
-    '    long_description = open("README.rst").read()\n'
-    'except IOError:\n'
-    '    long_description = ""\n'
-    '\n'
-    'setup(\n'
-    '${setup_lines}'
-    '    packages=find_packages(),\n'
-    '    install_requires=[],\n'
-    '    long_description=long_description\n'
-    ')\n'
-)
+setup_base_template = Template(dedent("""\
+    from setuptools import setup, find_packages
+
+    try:
+        long_description = open("README.rst").read()
+    except IOError:
+        long_description = ""
+
+    setup(
+    ${setup_lines}\
+    packages=find_packages(),
+        install_requires=[],
+        long_description=long_description
+    )
+    """))
 
 setup_line = Template(
     '    ${name}="${value}",\n'


### PR DESCRIPTION
Just to say you can check the equivalence like this:

```
from string import Template
from textwrap import dedent

setup_base_template = Template(
    'from setuptools import setup, find_packages\n'
    '\n'
    'try:\n'
    '    long_description = open("README.rst").read()\n'
    'except IOError:\n'
    '    long_description = ""\n'
    '\n'
    'setup(\n'
    '${setup_lines}'
    '    packages=find_packages(),\n'
    '    install_requires=[],\n'
    '    long_description=long_description\n'
    ')\n'
)

setup_base_template_dedent = Template(dedent("""\
    from setuptools import setup, find_packages

    try:
        long_description = open("README.rst").read()
    except IOError:
        long_description = ""

    setup(
    ${setup_lines}\
    packages=find_packages(),
        install_requires=[],
        long_description=long_description
    )
    """))

assert setup_base_template.template == setup_base_template_dedent.template
```
