### PR TITLE
utf-8 fix for #13

### DIFF
--- a/pip_init/__init__.py
+++ b/pip_init/__init__.py
@@ -73,7 +73,7 @@ def main():
         if version_info >= (3, 0):
             input_value = input(input_msg)
         else:
-            input_value = raw_input(input_msg.encode('utf8'))
+            input_value = raw_input(input_msg.encode('utf8')).decode('utf-8')
 
         if input_value == '':
             input_value = default_value

--- a/pip_init/templates.py
+++ b/pip_init/templates.py
@@ -4,6 +4,7 @@ from string import Template
 from textwrap import dedent
 
 setup_base_template = Template(dedent("""\
+    # -*- coding: utf-8 -*-
     from setuptools import setup, find_packages
 
     try:

--- a/tests/test_pip_init.py
+++ b/tests/test_pip_init.py
@@ -43,6 +43,7 @@ class TestPipInitTemplates(unittest.TestCase):
     def test_setup_base_template(self):
 
         expected_setup = (
+            '# -*- coding: utf-8 -*-\n'
             'from setuptools import setup, find_packages\n'
             '\n'
             'try:\n'


### PR DESCRIPTION
Fixes:
- non-ascii character in setup.py by declaring the file as utf-8 encoded
- output of `raw_input` is converted to unicode

Missing: 
- tests, I think it would be nice to cover the issue with tests to prevent regression later as these are non-trivial changes, but do not know how, so it would take more time than I can invest

Potential problems:
- non-utf-8 environments (Windows?)
- future regressions
